### PR TITLE
Focus when click on dropdown-filter-dropdown

### DIFF
--- a/src/FilterMenu.ts
+++ b/src/FilterMenu.ts
@@ -29,7 +29,11 @@ export class FilterMenu {
     let $menu = $(this.menu);
 
     // toggle hide/show when the trigger is clicked
-    $trigger.click(() => $content.toggle());
+    $trigger.click(function () {
+        $content.toggle();
+        $menu.find("input[type=text]").focus();
+        return;
+    });
 
     $(document).click(function(el) {
       // hide the content if the user clicks outside of the menu


### PR DESCRIPTION
Auto Focus on input type text when click on "dropdown-filter-dropdown" icon.
Maybe the use of `.find("input[type=text]")` isn't the best way but it works.