### PR TITLE
Prevent html-encoded content of a table to be rendered als mark-up in…

### DIFF
--- a/src/FilterCollection.ts
+++ b/src/FilterCollection.ts
@@ -105,7 +105,7 @@ export class FilterCollection {
     for (let i=0; i < rows.length; i++) {
       let tds = rows[i].children;
       for (let j=0; j < selectedLists.length; j++) {
-        let content = (tds[selectedLists[j].column] as HTMLElement).innerText.trim().replace(/ +(?= )/g,'')
+        let content = (tds[selectedLists[j].column] as HTMLElement).innerHTML.trim().replace(/ +(?= )/g,'')
         if (selectedLists[j].selected.indexOf(content) === -1 ) {
           $(rows[i]).hide();
           break;

--- a/src/FilterMenu.ts
+++ b/src/FilterMenu.ts
@@ -84,7 +84,7 @@ export class FilterMenu {
 
   private dropdownFilterItem(td: HTMLElement, self: any): HTMLElement {
     // build holder div
-    let value = td.innerText;
+    let value = td.innerHTML
     let dropdownFilterItem = document.createElement('div');
     dropdownFilterItem.className = 'dropdown-filter-item';
     // build input
@@ -160,8 +160,8 @@ export class FilterMenu {
 
     let innerDivs = this.tds.reduce(function(arr, el) {
       // get unique values in column
-      let values = arr.map((el) => el.innerText.trim());
-      if (values.indexOf(el.innerText.trim()) < 0) arr.push(el);
+      let values = arr.map((el) => el.innerHTML.trim());
+      if (values.indexOf(el.innerHTML.trim()) < 0) arr.push(el);
       // return unique values
       return arr;
     }, [])


### PR DESCRIPTION
… de table filter list of checkboxes.

Fix for [Html-encoded content of a table is rendered als mark-up in de table filter list of checkboxes](https://github.com/chestercharles/excel-bootstrap-table-filter/issues/25#issue-464608190).